### PR TITLE
Updating one line in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ref = BibleRef::Reference.new('jn 3:16')
 ref.valid?
 # true
 
-ref.book.id
+ref.book_id
 # "JHN"
 
 ref.normalize


### PR DESCRIPTION
Using
```
ref = BibleRef::Reference.new('jn 3:16')
```
and
```
ref.book.id
```
throws
```
NoMethodError: undefined method `id' for nil:NilClass
```

It looks like changes somewhere along the way now uses
```
ref.book_id
```

So I just updated that example for anyone else who may run into that.